### PR TITLE
feat: 生成回数上限到達お知らせダイアログを追加

### DIFF
--- a/lib/component/dialog/generation_limit_notice_dialog.dart
+++ b/lib/component/dialog/generation_limit_notice_dialog.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+import '../../import/component.dart';
+import '../../import/theme.dart';
+import '../../l10n/app_localizations.dart';
+
+/// 生成回数上限到達お知らせダイアログ
+class GenerationLimitNoticeDialog extends ConsumerWidget {
+  /// GenerationLimitNoticeDialogのコンストラクタ
+  const GenerationLimitNoticeDialog({super.key, required this.context});
+
+  /// ビルドコンテキスト
+  final BuildContext context;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final l10n = AppLocalizations.of(context)!;
+    final theme = ref.watch(appThemeProvider);
+
+    return AlertDialog(
+      backgroundColor: theme.appColors.white,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+      title: SizedBox(
+        width: double.infinity,
+        child: ThemeText(
+          text: l10n.generationLimitReachedTitle,
+          color: theme.appColors.black,
+          style: theme.textTheme.h50.bold(),
+          align: TextAlign.center,
+        ),
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          ThemeText(
+            text: l10n.generationLimitReachedMessage,
+            color: theme.appColors.black,
+            style: theme.textTheme.h30,
+            align: TextAlign.center,
+          ),
+          hSpace(height: 24),
+          // 閉じるボタン
+          DialogPrimaryButton(
+            text: l10n.close,
+            screen: 'generation_limit_notice_dialog',
+            width: double.infinity,
+            callback: () {
+              Navigator.of(context).pop();
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 生成回数上限到達お知らせダイアログを表示する関数
+Future<void> showGenerationLimitNoticeDialog({
+  required BuildContext context,
+}) async {
+  await showDialog<void>(
+    context: context,
+    barrierDismissible: false,
+    builder: (BuildContext context) {
+      return GenerationLimitNoticeDialog(context: context);
+    },
+  );
+}

--- a/lib/import/component.dart
+++ b/lib/import/component.dart
@@ -10,6 +10,7 @@ export '../component/chip/single_select_chip.dart';
 export '../component/dialog/action_dialog.dart';
 export '../component/dialog/calendar_dialog.dart';
 export '../component/dialog/generation_limit_dialog.dart';
+export '../component/dialog/generation_limit_notice_dialog.dart';
 export '../component/dialog/rating_dialog.dart';
 export '../component/dialog/two_button_dialog.dart';
 export '../component/form/custom_text_form_field.dart';

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1459,6 +1459,14 @@
   "@subscribeToPlan": {
     "description": "Text for subscription registration button"
   },
+  "generationLimitReachedTitle": "Generation limit reached",
+  "@generationLimitReachedTitle": {
+    "description": "Title for generation limit reached notice dialog"
+  },
+  "generationLimitReachedMessage": "You have reached the daily generation limit.\nPlease try again tomorrow.",
+  "@generationLimitReachedMessage": {
+    "description": "Message for generation limit reached notice dialog"
+  },
   "purchaseCompleted": "Purchase completed!",
   "selected": "Selected",
   "@selected": {

--- a/lib/l10n/app_es.arb
+++ b/lib/l10n/app_es.arb
@@ -1460,6 +1460,14 @@
   "@subscribeToPlan": {
     "description": "Texto para el botón de registro de suscripción"
   },
+  "generationLimitReachedTitle": "Límite de generación alcanzado",
+  "@generationLimitReachedTitle": {
+    "description": "Título del diálogo de aviso de límite de generación alcanzado"
+  },
+  "generationLimitReachedMessage": "Has alcanzado el límite diario de generación.\nPor favor, inténtalo de nuevo mañana.",
+  "@generationLimitReachedMessage": {
+    "description": "Mensaje del diálogo de aviso de límite de generación alcanzado"
+  },
   "purchaseCompleted": "¡Compra completada!",
   "selected": "Seleccionado",
   "@selected": {

--- a/lib/l10n/app_fr.arb
+++ b/lib/l10n/app_fr.arb
@@ -1460,6 +1460,14 @@
   "@adRewardMessage": {
     "description": "Message de récompense lorsque la visualisation de la publicité est terminée"
   },
+  "generationLimitReachedTitle": "Limite de génération atteinte",
+  "@generationLimitReachedTitle": {
+    "description": "Titre de la boîte de dialogue d'avis de limite de génération atteinte"
+  },
+  "generationLimitReachedMessage": "Vous avez atteint la limite quotidienne de génération.\nVeuillez réessayer demain.",
+  "@generationLimitReachedMessage": {
+    "description": "Message de la boîte de dialogue d'avis de limite de génération atteinte"
+  },
   "purchaseCompleted": "Achat terminé !",
   "@purchaseCompleted": {
     "description": "Message de succès lors de l'achat d'un abonnement"

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1456,6 +1456,14 @@
   "@adRewardMessage": {
     "description": "Messaggio di ricompensa quando la visualizzazione dell'annuncio è completata"
   },
+  "generationLimitReachedTitle": "Limite di generazione raggiunta",
+  "@generationLimitReachedTitle": {
+    "description": "Titolo della finestra di dialogo di avviso limite di generazione raggiunta"
+  },
+  "generationLimitReachedMessage": "Hai raggiunto il limite giornaliero di generazione.\nRiprova domani.",
+  "@generationLimitReachedMessage": {
+    "description": "Messaggio della finestra di dialogo di avviso limite di generazione raggiunta"
+  },
   "subscribeToPlan": "Abbonati al piano",
   "@subscribeToPlan": {
     "description": "Testo per il pulsante di registrazione abbonamento"

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1455,6 +1455,14 @@
   "@subscribeToPlan": {
     "description": "サブスクリプション登録ボタンのテキスト"
   },
+  "generationLimitReachedTitle": "生成回数の上限に達しました",
+  "@generationLimitReachedTitle": {
+    "description": "生成回数上限到達お知らせダイアログのタイトル"
+  },
+  "generationLimitReachedMessage": "本日の生成回数の上限に達しました。\n明日再度お試しください。",
+  "@generationLimitReachedMessage": {
+    "description": "生成回数上限到達お知らせダイアログのメッセージ"
+  },
   "purchaseCompleted": "購入が完了しました！",
   "@purchaseCompleted": {
     "description": "購入完了時のメッセージ"

--- a/lib/provider/music_generation_state_notifier.dart
+++ b/lib/provider/music_generation_state_notifier.dart
@@ -1166,13 +1166,9 @@ musicHistoryStreamProvider =
                       .where((history) {
                         final matches = history.userId == userId;
                         return matches;
-                      }) // クライアントサイドでフィルタリング
+                      })
                       .toList()
-                    ..sort(
-                      (a, b) => b.createdAt.compareTo(a.createdAt),
-                    ); // 最新順にソート
-
-              logger.d('=== 音楽履歴取得完了 ===');
+                    ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
               return historyList;
             })
             .handleError((Object error, StackTrace stackTrace) {
@@ -1228,8 +1224,6 @@ musicHistoryByIdStreamProvider = StreamProvider.autoDispose
                   logger.d('ユーザーIDが一致しません: ${history.userId} != $userId');
                   return null;
                 }
-
-                logger.d('=== 特定音楽履歴取得完了 ===');
                 return history;
               } on Exception catch (e) {
                 logger.e('ドキュメントのパースエラー: ${snapshot.id}', error: e);

--- a/lib/provider/music_player_state_notifier.dart
+++ b/lib/provider/music_player_state_notifier.dart
@@ -53,8 +53,6 @@ class MusicPlayerStateNotifier extends StateNotifier<PlayerState> {
       _audioPlayer.playingStream.listen((isPlaying) {
         state = state.copyWith(isPlaying: isPlaying);
       });
-
-      logger.d('オーディオプレイヤー初期化完了');
     } on PlayerException catch (e) {
       logger.e('Player exception: $e');
     } on Exception catch (e) {

--- a/lib/screen/home/audio_generation_screen.dart
+++ b/lib/screen/home/audio_generation_screen.dart
@@ -273,7 +273,8 @@ class AudioGenerationScreen extends HookConsumerWidget {
                               )
                               .generateMusic(request);
                         } else {
-                          showGenerationLimitDialog(context: context);
+                          // showGenerationLimitDialog(context: context);
+                          showGenerationLimitNoticeDialog(context: context);
                         }
                       },
                     ),


### PR DESCRIPTION
- 新しいダイアログ GenerationLimitNoticeDialog を作成
- 既存の showGenerationLimitDialog は保持
- 全言語のローカライゼーションファイルに新しいキーを追加
- シンプルなお知らせメッセージと閉じるボタンのみを提供
- audio_generation_screen.dart で新しいダイアログを呼び出すように変更

## 1. 何を行ったか

<!-- この PR で何を行ったかを記載 -->

- [ ] タスク URL

### 1-1. 注意して確認してほしい箇所

### 1-2. 個人情報の編集・表示処理を含むか

- [ ] 含む
- [ ] 含まない

### 1-3. 上記以外の既存箇所への影響があるか

- [ ] ある
- [ ] なし

<!-- 影響がある場合、その内容を記載 -->

## 2. この PR では対応していないこと、その他留意事項

## 3. 実装者動作確認

- 実装・影響箇所
  - [ ] Android
  - [ ] iOS
- [ ] なし・不要

- 共通確認項目(自動テスト使用可)
  - [ ] Android
  - [ ] iOS

## 4. チェックリスト

- [ ] 仕様が無いか、あれば仕様の通りに動作することを確認しました
- [ ] コーディング規約・スタイルガイドに違反していません（README に記載のツールで確認）
- [ ] 画像等の静的ファイルが無いか、あればサイズ最適化・圧縮済みです
- [ ] 実装とその影響箇所、共通確認項目全てで動作確認もしくは自動テストを行い、エラーログで問題がないことを確認しました
